### PR TITLE
fix for PHP 5.5

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -28,7 +28,7 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 #include "php_xhprof.h"
-#include "Zend/zend_extensions.h"
+#include "zend_extensions.h"
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <stdlib.h>
@@ -233,12 +233,21 @@ typedef struct hp_global_t {
 /* XHProf global state */
 static hp_global_t       hp_globals;
 
+#if PHP_VERSION_ID < 50500
 /* Pointer to the original execute function */
 static ZEND_DLEXPORT void (*_zend_execute) (zend_op_array *ops TSRMLS_DC);
 
 /* Pointer to the origianl execute_internal function */
 static ZEND_DLEXPORT void (*_zend_execute_internal) (zend_execute_data *data,
                            int ret TSRMLS_DC);
+#else
+/* Pointer to the original execute function */
+static void (*_zend_execute_ex) (zend_execute_data *execute_data TSRMLS_DC);
+
+/* Pointer to the origianl execute_internal function */
+static void (*_zend_execute_internal) (zend_execute_data *data,
+                      struct _zend_fcall_info *fci, int ret TSRMLS_DC);
+#endif
 
 /* Pointer to the original compile function */
 static zend_op_array * (*_zend_compile_file) (zend_file_handle *file_handle,
@@ -880,8 +889,8 @@ size_t hp_get_function_stack(hp_entry_t *entry,
  * a pointer to one-level directory and basefile name
  * (d/foo.php) in the same string.
  */
-static char *hp_get_base_filename(char *filename) {
-  char *ptr;
+static const char *hp_get_base_filename(const char *filename) {
+  const char *ptr;
   int   found = 0;
 
   if (!filename)
@@ -909,7 +918,7 @@ static char *hp_get_base_filename(char *filename) {
  */
 static char *hp_get_function_name(zend_op_array *ops TSRMLS_DC) {
   zend_execute_data *data;
-  char              *func = NULL;
+  const char        *func = NULL;
   const char        *cls = NULL;
   char              *ret = NULL;
   int                len;
@@ -988,7 +997,7 @@ static char *hp_get_function_name(zend_op_array *ops TSRMLS_DC) {
        * you'll see something like "run_init::foo.php" in your reports.
        */
       if (add_filename){
-        char *filename;
+        const char *filename;
         int   len;
         filename = hp_get_base_filename((curr_func->op_array).filename);
         len      = strlen("run_init") + strlen(filename) + 3;
@@ -1629,18 +1638,31 @@ void hp_mode_sampled_endfn_cb(hp_entry_t **entries  TSRMLS_DC) {
  *
  * @author hzhao, kannan
  */
+#if PHP_VERSION_ID < 50500
 ZEND_DLEXPORT void hp_execute (zend_op_array *ops TSRMLS_DC) {
+#else
+ZEND_DLEXPORT void hp_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
+  zend_op_array *ops = execute_data->op_array;
+#endif
   char          *func = NULL;
   int hp_profile_flag = 1;
 
   func = hp_get_function_name(ops TSRMLS_CC);
   if (!func) {
+#if PHP_VERSION_ID < 50500
     _zend_execute(ops TSRMLS_CC);
+#else
+    _zend_execute_ex(execute_data TSRMLS_CC);
+#endif
     return;
   }
 
   BEGIN_PROFILING(&hp_globals.entries, func, hp_profile_flag);
+#if PHP_VERSION_ID < 50500
   _zend_execute(ops TSRMLS_CC);
+#else
+  _zend_execute_ex(execute_data TSRMLS_CC);
+#endif
   if (hp_globals.entries) {
     END_PROFILING(&hp_globals.entries, hp_profile_flag);
   }
@@ -1649,7 +1671,6 @@ ZEND_DLEXPORT void hp_execute (zend_op_array *ops TSRMLS_DC) {
 
 #undef EX
 #define EX(element) ((execute_data)->element)
-#define EX_T(offset) (*(temp_variable *)((char *) EX(Ts) + offset))
 
 /**
  * Very similar to hp_execute. Proxy for zend_execute_internal().
@@ -1657,8 +1678,18 @@ ZEND_DLEXPORT void hp_execute (zend_op_array *ops TSRMLS_DC) {
  *
  * @author hzhao, kannan
  */
+
+#if PHP_VERSION_ID < 50500
+#define EX_T(offset) (*(temp_variable *)((char *) EX(Ts) + offset))
+
 ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
                                        int ret TSRMLS_DC) {
+#else
+#define EX_T(offset) (*EX_TMP_VAR(execute_data, offset))
+
+ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
+                                       struct _zend_fcall_info *fci, int ret TSRMLS_DC) {
+#endif
   zend_execute_data *current_data;
   char             *func = NULL;
   int    hp_profile_flag = 1;
@@ -1691,7 +1722,11 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 #endif
   } else {
     /* call the old override */
+#if PHP_VERSION_ID < 50500
     _zend_execute_internal(execute_data, ret TSRMLS_CC);
+#else
+    _zend_execute_internal(execute_data, fci, ret TSRMLS_CC);
+#endif
   }
 
   if (func) {
@@ -1711,7 +1746,7 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 ZEND_DLEXPORT zend_op_array* hp_compile_file(zend_file_handle *file_handle,
                                              int type TSRMLS_DC) {
 
-  char           *filename;
+  const char     *filename;
   char           *func;
   int             len;
   zend_op_array  *ret;
@@ -1783,8 +1818,13 @@ static void hp_begin(long level, long xhprof_flags TSRMLS_DC) {
     zend_compile_string = hp_compile_string;
 
     /* Replace zend_execute with our proxy */
+#if PHP_VERSION_ID < 50500
     _zend_execute = zend_execute;
     zend_execute  = hp_execute;
+#else
+    _zend_execute_ex = zend_execute_ex;
+    zend_execute_ex  = hp_execute_ex;
+#endif
 
     /* Replace zend_execute_internal with our proxy */
     _zend_execute_internal = zend_execute_internal;
@@ -1855,7 +1895,11 @@ static void hp_stop(TSRMLS_D) {
   }
 
   /* Remove proxies, restore the originals */
+#if PHP_VERSION_ID < 50500
   zend_execute          = _zend_execute;
+#else
+  zend_execute_ex       = _zend_execute_ex;
+#endif
   zend_execute_internal = _zend_execute_internal;
   zend_compile_file     = _zend_compile_file;
   zend_compile_string   = _zend_compile_string;


### PR DESCRIPTION
This patch fix this extension for PHP 5.5 (and a few build warnings)

Mostly inspired by xdebug and APC fixes.

Build : ok without warning
Load : ok with php 5.5 snapshot 201301021430
Profiling : ok
