### PR TITLE
Fixed trailing slash trim on Windows.

### DIFF
--- a/xhprof_lib/display/xhprof.php
+++ b/xhprof_lib/display/xhprof.php
@@ -42,7 +42,7 @@ require_once $GLOBALS['XHPROF_LIB_ROOT'].'/utils/xhprof_runs.php';
  * Our coding convention disallows relative paths in hrefs.
  * Get the base URL path from the SCRIPT_NAME.
  */
-$base_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
+$base_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
 
 
 /**
@@ -58,7 +58,7 @@ $base_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
 function xhprof_include_js_css($ui_dir_url_path = null) {
 
   if (empty($ui_dir_url_path)) {
-    $ui_dir_url_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), "/");
+    $ui_dir_url_path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
   }
 
   // style sheets


### PR DESCRIPTION
Couple places currently hardcoded to trim Linux-style slash from paths, which causes broken resource and others link on Windows.
