### PR TITLE
XHProf PHP-extension - added Win(NT/32) compatibility (only extension changed)

### DIFF
--- a/extension/php_xhprof.h
+++ b/extension/php_xhprof.h
@@ -23,6 +23,8 @@ extern zend_module_entry xhprof_module_entry;
 
 #ifdef PHP_WIN32
 #define PHP_XHPROF_API __declspec(dllexport)
+#include "win32/php_xhprof_win32.h"
+#include "win32/php_xhprof_win32.c"
 #else
 #define PHP_XHPROF_API
 #endif
@@ -31,15 +33,23 @@ extern zend_module_entry xhprof_module_entry;
 #include "TSRM.h"
 #endif
 
+/**
+ * PHP default module methods
+ */
 PHP_MINIT_FUNCTION(xhprof);
 PHP_MSHUTDOWN_FUNCTION(xhprof);
 PHP_RINIT_FUNCTION(xhprof);
 PHP_RSHUTDOWN_FUNCTION(xhprof);
 PHP_MINFO_FUNCTION(xhprof);
 
+/**
+ * declare methods available in PHP
+ */
 PHP_FUNCTION(xhprof_enable);
 PHP_FUNCTION(xhprof_disable);
+PHP_FUNCTION(xhprof_debug);
 PHP_FUNCTION(xhprof_sample_enable);
 PHP_FUNCTION(xhprof_sample_disable);
 
-#endif	/* PHP_XHPROF_H */
+#endif  /* PHP_XHPROF_H */
+

--- a/extension/win32/README.md
+++ b/extension/win32/README.md
@@ -1,0 +1,11 @@
+XHProf windows builds
+===
+
+More information
+-------------------------
+Visit my blog www.phpfluesterer.de to get in contact with me if you have trouble building XHProf on windows or if you're looking for the latest windows builds.
+
+
+Latest windows builds
+-------------------------
+http://www.phpfluesterer.de/projekte/open-source-software-projekte/xhprof-php-extension/xhprof-fur-windows-aktuelle-windows-builds/

--- a/extension/win32/php_xhprof_win32.c
+++ b/extension/win32/php_xhprof_win32.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ *  Copyright (c) 2010 - 2012 Benjamin Carl
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ***************************************************************************/
+
+int getrusage(int who, struct rusage * rusage)
+{
+    FILETIME starttime;
+    FILETIME exittime;
+    FILETIME kerneltime;
+    FILETIME usertime;
+    ULARGE_INTEGER li;
+
+    if (who != RUSAGE_SELF) {
+        // Only RUSAGE_SELF is supported in this implementation for now
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (rusage == (struct rusage *) NULL)
+    {
+        errno = EFAULT;
+        return -1;
+    }
+
+    memset(rusage, 0, sizeof(struct rusage));
+
+    if (GetProcessTimes(GetCurrentProcess(),
+                        &starttime, &exittime, &kerneltime, &usertime) == 0)
+    {
+        return -1;
+    }
+
+    /* Convert FILETIMEs (0.1 us) to struct timeval */
+    memcpy(&li, &kerneltime, sizeof(FILETIME));
+    li.QuadPart /= 10L;         /* Convert to microseconds */
+    rusage->ru_stime.tv_sec = (long)li.QuadPart / 1000000L;
+    rusage->ru_stime.tv_usec = (long)li.QuadPart % 1000000L;
+
+    memcpy(&li, &usertime, sizeof(FILETIME));
+    li.QuadPart /= 10L;         /* Convert to microseconds */
+    rusage->ru_utime.tv_sec = (long)li.QuadPart / 1000000L;
+    rusage->ru_utime.tv_usec = (long)li.QuadPart % 1000000L;
+
+
+    // success
+    return 0;
+}

--- a/extension/win32/php_xhprof_win32.h
+++ b/extension/win32/php_xhprof_win32.h
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *  Copyright (c) 2010 - 2012 Benjamin Carl
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ***************************************************************************/
+
+#ifndef PHP_XHPROF_WIN32_H
+#define PHP_XHPROF_WIN32_H
+
+
+/****************************************************************************
+
+    windows specific data-type, definitions, ...
+
+****************************************************************************/
+#include <windows.h>
+
+#ifdef _MSC_VER
+    typedef __int32 int32_t;
+    typedef unsigned __int32 uint32_t;
+    typedef __int64 int64_t;
+    typedef unsigned __int64 uint64_t;
+#else
+    #include <stdint.h>
+#endif
+
+#if !defined(uint64)
+    typedef unsigned __int64 uint64;
+#define uint64 uint64
+#endif
+
+
+/****************************************************************************
+
+  sysconf() replacement win32 = sysinfo()
+
+****************************************************************************/
+SYSTEM_INFO sysinfo;
+
+
+/****************************************************************************
+
+    cpu_set_t
+
+****************************************************************************/
+#if !defined(cpu_set_t)
+    typedef unsigned long cpu_set_t;
+#endif
+
+
+/****************************************************************************
+
+    rusage
+
+****************************************************************************/
+#ifdef WIN32
+#include <time.h>               /* for struct timeval */
+#endif
+#ifndef WIN32
+#include <sys/time.h>           /* for struct timeval */
+#include <sys/times.h>          /* for struct tms */
+#endif
+#include <limits.h>             /* for CLK_TCK */
+
+#define RUSAGE_SELF     0
+#define RUSAGE_CHILDREN (-1)
+
+struct rusage {
+    struct timeval ru_utime;    /* user time used */
+    struct timeval ru_stime;    /* system time used */
+};
+
+extern int getrusage(int who, struct rusage * rusage);
+
+
+#endif  /* PHP_XHPROF_WIN32_H */

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -20,7 +20,7 @@
 #endif
 
 #ifdef linux
-/* To enable CPU_ZERO and CPU_SET, etc.     */
+/* To enable CPU_ZERO and CPU_SET, etc. */
 # define _GNU_SOURCE
 #endif
 
@@ -28,7 +28,7 @@
 #include "php_ini.h"
 #include "ext/standard/info.h"
 #include "php_xhprof.h"
-#include "zend_extensions.h"
+#include "Zend/zend_extensions.h"
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <stdlib.h>
@@ -60,6 +60,16 @@
 #   define SET_AFFINITY(pid, size, mask)       \
         thread_policy_set(mach_thread_self(), THREAD_AFFINITY_POLICY, mask, \
                           THREAD_AFFINITY_POLICY_COUNT)
+#elif PHP_WIN32
+/*
+ * Patch for compiling in Win32/64
+ * @author Benjamin Carl <opensource@clickalicious.de>
+ */
+#    define CPU_SET(cpu_id, new_mask) (*(new_mask)) = (cpu_id + 1)
+#    define CPU_ZERO(new_mask) (*(new_mask)) = 0
+#    define SET_AFFINITY(pid, size, mask) SetProcessAffinityMask(GetCurrentProcess(), (DWORD_PTR)mask)
+#    define GET_AFFINITY(pid, size, mask) \
+                      GetProcessAffinityMask(GetCurrentProcess(), mask, &s_mask)
 #else
 /* For sched_getaffinity, sched_setaffinity */
 # include <sched.h>
@@ -75,14 +85,14 @@
  * **********************
  */
 
-/* XHProf version                           */
-#define XHPROF_VERSION       "0.9.2"
+/* XHProf version */
+#define XHPROF_VERSION             "0.10.4"
 
 /* Fictitious function name to represent top of the call tree. The paranthesis
  * in the name is to ensure we don't conflict with user function names.  */
 #define ROOT_SYMBOL                "main()"
 
-/* Size of a temp scratch buffer            */
+/* Size of a temp scratch buffer */
 #define SCRATCH_BUF_LEN            512
 
 /* Various XHPROF modes. If you are adding a new mode, register the appropriate
@@ -96,12 +106,13 @@
  * The following optional flags can be used to control other aspects of
  * profiling.
  */
-#define XHPROF_FLAGS_NO_BUILTINS   0x0001         /* do not profile builtins */
-#define XHPROF_FLAGS_CPU           0x0002      /* gather CPU times for funcs */
+#define XHPROF_FLAGS_NO_BUILTINS   0x0001   /* do not profile builtins */
+#define XHPROF_FLAGS_CPU           0x0002   /* gather CPU times for funcs */
 #define XHPROF_FLAGS_MEMORY        0x0004   /* gather memory usage for funcs */
+#define XHPROF_FLAGS_LONGNAMES     0x0008   /* use long filenames in reports */
 
-/* Constants for XHPROF_MODE_SAMPLED        */
-#define XHPROF_SAMPLING_INTERVAL       100000      /* In microsecs        */
+/* Constants for XHPROF_MODE_SAMPLED */
+#define XHPROF_SAMPLING_INTERVAL       100000      /* In microsecs */
 
 /* Constant for ignoring functions, transparent to hierarchical profile */
 #define XHPROF_MAX_IGNORED_FUNCTIONS  256
@@ -233,12 +244,13 @@ typedef struct hp_global_t {
 /* XHProf global state */
 static hp_global_t       hp_globals;
 
+
 #if PHP_VERSION_ID < 50500
 /* Pointer to the original execute function */
-static ZEND_DLEXPORT void (*_zend_execute) (zend_op_array *ops TSRMLS_DC);
+ZEND_DLEXPORT void (*_zend_execute) (zend_op_array *ops TSRMLS_DC);
 
 /* Pointer to the origianl execute_internal function */
-static ZEND_DLEXPORT void (*_zend_execute_internal) (zend_execute_data *data,
+ZEND_DLEXPORT void (*_zend_execute_internal) (zend_execute_data *data,
                            int ret TSRMLS_DC);
 #else
 /* Pointer to the original execute function */
@@ -248,6 +260,7 @@ static void (*_zend_execute_ex) (zend_execute_data *execute_data TSRMLS_DC);
 static void (*_zend_execute_internal) (zend_execute_data *data,
                       struct _zend_fcall_info *fci, int ret TSRMLS_DC);
 #endif
+
 
 /* Pointer to the original compile function */
 static zend_op_array * (*_zend_compile_file) (zend_file_handle *file_handle,
@@ -302,6 +315,9 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO(arginfo_xhprof_disable, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_xhprof_debug, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_xhprof_sample_enable, 0)
 ZEND_END_ARG_INFO()
 
@@ -326,6 +342,7 @@ int bind_to_cpu(uint32 cpu_id);
 zend_function_entry xhprof_functions[] = {
   PHP_FE(xhprof_enable, arginfo_xhprof_enable)
   PHP_FE(xhprof_disable, arginfo_xhprof_disable)
+  PHP_FE(xhprof_debug, arginfo_xhprof_debug)
   PHP_FE(xhprof_sample_enable, arginfo_xhprof_sample_enable)
   PHP_FE(xhprof_sample_disable, arginfo_xhprof_sample_disable)
   {NULL, NULL, NULL}
@@ -409,6 +426,17 @@ PHP_FUNCTION(xhprof_disable) {
 }
 
 /**
+ * Returns information about the environment XHProf is running in
+ *
+ * @param  void
+ * @return 
+ * @author Benjamin Carl <opensource@clickalicious.de>
+ */
+PHP_FUNCTION(xhprof_debug) {
+    //
+}
+
+/**
  * Start XHProf profiling in sampling mode.
  *
  * @return void
@@ -443,13 +471,19 @@ PHP_FUNCTION(xhprof_sample_disable) {
  */
 PHP_MINIT_FUNCTION(xhprof) {
   int i;
+  unsigned long s_mask;
 
   REGISTER_INI_ENTRIES();
 
   hp_register_constants(INIT_FUNC_ARGS_PASSTHRU);
 
   /* Get the number of available logical CPUs. */
+#ifndef PHP_WIN32
   hp_globals.cpu_num = sysconf(_SC_NPROCESSORS_CONF);
+#else
+  GetSystemInfo(&sysinfo);
+  hp_globals.cpu_num = sysinfo.dwNumberOfProcessors;
+#endif
 
   /* Get the cpu affinity mask. */
 #ifndef __APPLE__
@@ -464,7 +498,6 @@ PHP_MINIT_FUNCTION(xhprof) {
   /* Initialize cpu_frequencies and cur_cpu_id. */
   hp_globals.cpu_frequencies = NULL;
   hp_globals.cur_cpu_id = 0;
-
   hp_globals.stats_count = NULL;
 
   /* no free hp_entry_t structures to start with */
@@ -520,14 +553,22 @@ PHP_MINFO_FUNCTION(xhprof)
 {
   char buf[SCRATCH_BUF_LEN];
   char tmp[SCRATCH_BUF_LEN];
-  int i;
+  /* Note(bcarl): changed to uint32 like defined in struct -> hp_global_t */
+  uint32 i;
+
   int len;
 
+
   php_info_print_table_start();
-  php_info_print_table_header(2, "xhprof", XHPROF_VERSION);
+  php_info_print_table_row(2, "xhprof", "enabled");
+  php_info_print_table_row(2, "xhprof version", XHPROF_VERSION);
   len = snprintf(buf, SCRATCH_BUF_LEN, "%d", hp_globals.cpu_num);
   buf[len] = 0;
-  php_info_print_table_header(2, "CPU num", buf);
+  php_info_print_table_row(2, "CPU num", buf);
+  /* information about the cpu the process is bound to */
+  len = snprintf(tmp, SCRATCH_BUF_LEN, "%d", hp_globals.cur_cpu_id);
+  tmp[len] = 0;
+  php_info_print_table_row(2, "process bound to CPU", tmp);
 
   if (hp_globals.cpu_frequencies) {
     /* Print available cpu frequencies here. */
@@ -535,7 +576,7 @@ PHP_MINFO_FUNCTION(xhprof)
     for (i = 0; i < hp_globals.cpu_num; ++i) {
       len = snprintf(buf, SCRATCH_BUF_LEN, " CPU %d ", i);
       buf[len] = 0;
-      len = snprintf(tmp, SCRATCH_BUF_LEN, "%f", hp_globals.cpu_frequencies[i]);
+      len = snprintf(tmp, SCRATCH_BUF_LEN, "%-.0f", hp_globals.cpu_frequencies[i]);
       tmp[len] = 0;
       php_info_print_table_row(2, buf, tmp);
     }
@@ -562,6 +603,9 @@ static void hp_register_constants(INIT_FUNC_ARGS) {
 
   REGISTER_LONG_CONSTANT("XHPROF_FLAGS_MEMORY",
                          XHPROF_FLAGS_MEMORY,
+                         CONST_CS | CONST_PERSISTENT);
+  REGISTER_LONG_CONSTANT("XHPROF_FLAGS_LONGNAMES",
+                         XHPROF_FLAGS_LONGNAMES,
                          CONST_CS | CONST_PERSISTENT);
 }
 
@@ -673,7 +717,7 @@ void hp_init_profiler_state(int level TSRMLS_DC) {
   }
 
   /* bind to a random cpu so that we can use rdtsc instruction. */
-  bind_to_cpu((int) (rand() % hp_globals.cpu_num));
+  bind_to_cpu( (rand() % hp_globals.cpu_num) + 1);
 
   /* Call current mode's init cb */
   hp_globals.mode_cb.init_cb(TSRMLS_C);
@@ -772,6 +816,7 @@ void hp_clean_profiler_state(TSRMLS_D) {
 size_t hp_get_entry_name(hp_entry_t  *entry,
                          char           *result_buf,
                          size_t          result_len) {
+  size_t    len = 0;
 
   /* Validate result_len */
   if (result_len <= 1) {
@@ -801,7 +846,7 @@ size_t hp_get_entry_name(hp_entry_t  *entry,
 /**
  * Check if this entry should be ignored, first with a conservative Bloomish
  * filter then with an exact check against the function names.
- *
+ * 
  * @author mpal
  */
 int  hp_ignore_entry_work(uint8 hash_code, char *curr_func) {
@@ -889,13 +934,17 @@ size_t hp_get_function_stack(hp_entry_t *entry,
  * a pointer to one-level directory and basefile name
  * (d/foo.php) in the same string.
  */
-static const char *hp_get_base_filename(const char *filename) {
-  const char *ptr;
+static char *hp_get_base_filename(char *filename) {
+  char *ptr;
   int   found = 0;
 
   if (!filename)
     return "";
 
+  /* return complete filename if requested */
+  if (hp_globals.xhprof_flags & XHPROF_FLAGS_LONGNAMES) {
+      return filename;
+  }
   /* reverse search for "/" and return a ptr to the next char */
   for (ptr = filename + strlen(filename) - 1; ptr >= filename; ptr--) {
     if (*ptr == '/') {
@@ -918,11 +967,11 @@ static const char *hp_get_base_filename(const char *filename) {
  */
 static char *hp_get_function_name(zend_op_array *ops TSRMLS_DC) {
   zend_execute_data *data;
-  const char        *func = NULL;
-  const char        *cls = NULL;
-  char              *ret = NULL;
+  char              *func = NULL;
+  const char        *cls  = NULL;
+  char              *ret  = NULL;
   int                len;
-  zend_function      *curr_func;
+  zend_function     *curr_func;
 
   data = EG(current_execute_data);
 
@@ -997,7 +1046,7 @@ static char *hp_get_function_name(zend_op_array *ops TSRMLS_DC) {
        * you'll see something like "run_init::foo.php" in your reports.
        */
       if (add_filename){
-        const char *filename;
+        char *filename;
         int   len;
         filename = hp_get_base_filename((curr_func->op_array).filename);
         len      = strlen("run_init") + strlen(filename) + 3;
@@ -1135,9 +1184,9 @@ void hp_trunc_time(struct timeval *tv,
   time_in_micro /= intr;
   time_in_micro *= intr;
 
-  /* Update tv */
-  tv->tv_sec  = (time_in_micro / 1000000);
-  tv->tv_usec = (time_in_micro % 1000000);
+  /* Update tv Note(bcarl): added explicit typecasting (long) warning C4244 */
+  tv->tv_sec  = (long)(time_in_micro / 1000000);
+  tv->tv_usec = (long)(time_in_micro % 1000000);
 }
 
 /**
@@ -1221,7 +1270,18 @@ void hp_sample_check(hp_entry_t **entries  TSRMLS_DC) {
 inline uint64 cycle_timer() {
   uint32 __a,__d;
   uint64 val;
+
+#ifdef PHP_WIN32
+  __asm {
+    cpuid
+    rdtsc
+    mov __a, eax
+    mov __d, edx
+  }
+#else
   asm volatile("rdtsc" : "=a" (__a), "=d" (__d));
+#endif
+
   (val) = ((uint64)__a) | (((uint64)__d)<<32);
   return val;
 }
@@ -1266,8 +1326,8 @@ static long get_us_interval(struct timeval *start, struct timeval *end) {
  */
 static void incr_us_interval(struct timeval *start, uint64 incr) {
   incr += (start->tv_sec * 1000000 + start->tv_usec);
-  start->tv_sec  = incr/1000000;
-  start->tv_usec = incr%1000000;
+  start->tv_sec  = (long)(incr/1000000);
+  start->tv_usec = (long)(incr%1000000);
   return;
 }
 
@@ -1307,20 +1367,26 @@ inline uint64 get_tsc_from_us(uint64 usecs, double cpu_frequency) {
 static double get_cpu_frequency() {
   struct timeval start;
   struct timeval end;
+  uint64 tsc_start;
+  uint64 tsc_end;
 
   if (gettimeofday(&start, 0)) {
     perror("gettimeofday");
     return 0.0;
   }
-  uint64 tsc_start = cycle_timer();
-  /* Sleep for 5 miliseconds. Comparaing with gettimeofday's  few microseconds
+  
+  tsc_start = cycle_timer();
+
+  /* Sleep for 5 miliseconds. Comparaing with gettimeofday's few microseconds
    * execution time, this should be enough. */
   usleep(5000);
   if (gettimeofday(&end, 0)) {
     perror("gettimeofday");
     return 0.0;
   }
-  uint64 tsc_end = cycle_timer();
+  
+  tsc_end = cycle_timer();
+
   return (tsc_end - tsc_start) * 1.0 / (get_us_interval(&start, &end));
 }
 
@@ -1330,8 +1396,7 @@ static double get_cpu_frequency() {
  * @author cjiang
  */
 static void get_all_cpu_frequencies() {
-  int id;
-  double frequency;
+  uint32 id;
 
   hp_globals.cpu_frequencies = malloc(sizeof(double) * hp_globals.cpu_num);
   if (hp_globals.cpu_frequencies == NULL) {
@@ -1341,21 +1406,13 @@ static void get_all_cpu_frequencies() {
   /* Iterate over all cpus found on the machine. */
   for (id = 0; id < hp_globals.cpu_num; ++id) {
     /* Only get the previous cpu affinity mask for the first call. */
-    if (bind_to_cpu(id)) {
-      clear_frequencies();
-      return;
-    }
+    bind_to_cpu(id);
 
     /* Make sure the current process gets scheduled to the target cpu. This
      * might not be necessary though. */
     usleep(0);
 
-    frequency = get_cpu_frequency();
-    if (frequency == 0.0) {
-      clear_frequencies();
-      return;
-    }
-    hp_globals.cpu_frequencies[id] = frequency;
+    hp_globals.cpu_frequencies[id] = get_cpu_frequency();
   }
 }
 
@@ -1476,6 +1533,11 @@ void hp_mode_sampled_init_cb(TSRMLS_D) {
   uint64 truncated_tsc;
   double cpu_freq = hp_globals.cpu_frequencies[hp_globals.cur_cpu_id];
 
+  if (cpu_freq == 0.0) {
+    /* There is an insignificant chance that cpu_freq equals 0 
+       and we cannot do anything in this case */
+    return;
+  }
   /* Init the last_sample in tsc */
   hp_globals.last_sample_tsc = cycle_timer();
 
@@ -1566,7 +1628,7 @@ zval * hp_mode_shared_endfn_cb(hp_entry_t *top,
   /* Bump stats in the counts hashtable */
   hp_inc_count(counts, "ct", 1  TSRMLS_CC);
 
-  hp_inc_count(counts, "wt", get_us_from_tsc(tsc_end - top->tsc_start,
+  hp_inc_count(counts, "wt", (long)get_us_from_tsc(tsc_end - top->tsc_start,
         hp_globals.cpu_frequencies[hp_globals.cur_cpu_id]) TSRMLS_CC);
   return counts;
 }
@@ -1638,31 +1700,18 @@ void hp_mode_sampled_endfn_cb(hp_entry_t **entries  TSRMLS_DC) {
  *
  * @author hzhao, kannan
  */
-#if PHP_VERSION_ID < 50500
 ZEND_DLEXPORT void hp_execute (zend_op_array *ops TSRMLS_DC) {
-#else
-ZEND_DLEXPORT void hp_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
-  zend_op_array *ops = execute_data->op_array;
-#endif
   char          *func = NULL;
   int hp_profile_flag = 1;
 
   func = hp_get_function_name(ops TSRMLS_CC);
   if (!func) {
-#if PHP_VERSION_ID < 50500
     _zend_execute(ops TSRMLS_CC);
-#else
-    _zend_execute_ex(execute_data TSRMLS_CC);
-#endif
     return;
   }
 
   BEGIN_PROFILING(&hp_globals.entries, func, hp_profile_flag);
-#if PHP_VERSION_ID < 50500
   _zend_execute(ops TSRMLS_CC);
-#else
-  _zend_execute_ex(execute_data TSRMLS_CC);
-#endif
   if (hp_globals.entries) {
     END_PROFILING(&hp_globals.entries, hp_profile_flag);
   }
@@ -1671,6 +1720,7 @@ ZEND_DLEXPORT void hp_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
 
 #undef EX
 #define EX(element) ((execute_data)->element)
+#define EX_T(offset) (*(temp_variable *)((char *) EX(Ts) + offset))
 
 /**
  * Very similar to hp_execute. Proxy for zend_execute_internal().
@@ -1678,18 +1728,8 @@ ZEND_DLEXPORT void hp_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
  *
  * @author hzhao, kannan
  */
-
-#if PHP_VERSION_ID < 50500
-#define EX_T(offset) (*(temp_variable *)((char *) EX(Ts) + offset))
-
 ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
                                        int ret TSRMLS_DC) {
-#else
-#define EX_T(offset) (*EX_TMP_VAR(execute_data, offset))
-
-ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
-                                       struct _zend_fcall_info *fci, int ret TSRMLS_DC) {
-#endif
   zend_execute_data *current_data;
   char             *func = NULL;
   int    hp_profile_flag = 1;
@@ -1719,14 +1759,11 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
                        EX(function_state).function->common.return_reference ?
                        &EX_T(opline->result.u.var).var.ptr:NULL,
                        EX(object), ret TSRMLS_CC);
+
 #endif
   } else {
     /* call the old override */
-#if PHP_VERSION_ID < 50500
     _zend_execute_internal(execute_data, ret TSRMLS_CC);
-#else
-    _zend_execute_internal(execute_data, fci, ret TSRMLS_CC);
-#endif
   }
 
   if (func) {
@@ -1746,7 +1783,7 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 ZEND_DLEXPORT zend_op_array* hp_compile_file(zend_file_handle *file_handle,
                                              int type TSRMLS_DC) {
 
-  const char     *filename;
+  char           *filename;
   char           *func;
   int             len;
   zend_op_array  *ret;
@@ -1766,6 +1803,7 @@ ZEND_DLEXPORT zend_op_array* hp_compile_file(zend_file_handle *file_handle,
   efree(func);
   return ret;
 }
+
 
 /**
  * Proxy for zend_compile_string(). Used to profile PHP eval compilation time.
@@ -1818,13 +1856,8 @@ static void hp_begin(long level, long xhprof_flags TSRMLS_DC) {
     zend_compile_string = hp_compile_string;
 
     /* Replace zend_execute with our proxy */
-#if PHP_VERSION_ID < 50500
     _zend_execute = zend_execute;
     zend_execute  = hp_execute;
-#else
-    _zend_execute_ex = zend_execute_ex;
-    zend_execute_ex  = hp_execute_ex;
-#endif
 
     /* Replace zend_execute_internal with our proxy */
     _zend_execute_internal = zend_execute_internal;
@@ -1895,16 +1928,12 @@ static void hp_stop(TSRMLS_D) {
   }
 
   /* Remove proxies, restore the originals */
-#if PHP_VERSION_ID < 50500
   zend_execute          = _zend_execute;
-#else
-  zend_execute_ex       = _zend_execute_ex;
-#endif
   zend_execute_internal = _zend_execute_internal;
   zend_compile_file     = _zend_compile_file;
   zend_compile_string   = _zend_compile_string;
 
-  /* Resore cpu affinity. */
+  /* Restore cpu affinity. */
   restore_cpu_affinity(&hp_globals.prev_mask);
 
   /* Stop profiling */
@@ -1919,8 +1948,8 @@ static void hp_stop(TSRMLS_D) {
  */
 
 /** Look in the PHP assoc array to find a key and return the zval associated
- *  with it.
- *
+ *  with it.  
+ *  
  *  @author mpal
  **/
 static zval *hp_zval_at_key(char  *key,


### PR DESCRIPTION
hi

i did some slightly changes to the source-files of the XHProf PHP-extension to make it compilable to Windows platforms. I also did some minor changes to some parts of the code and removed some unreferenced variables to remove compiler warnings.
