### PR TITLE
Numformat fix

### DIFF
--- a/xhprof_lib/display/xhprof.php
+++ b/xhprof_lib/display/xhprof.php
@@ -621,7 +621,7 @@ function print_td_num($num, $fmt_func, $bold=false, $attributes=null) {
 
   $class = get_print_class($num, $bold);
 
-  if (!empty($fmt_func) && !is_string($num) ) {
+  if (!empty($fmt_func) && is_numeric($num) ) {
     $num = call_user_func($fmt_func, $num);
   }
 


### PR DESCRIPTION
Since numformat function can not format strings like 'N/A', we need to check for the string value.
