### PR TITLE
Tweaked proc_open() call for callgraph to work on Windows

### DIFF
--- a/xhprof_lib/utils/callgraph_utils.php
+++ b/xhprof_lib/utils/callgraph_utils.php
@@ -109,7 +109,7 @@ function xhprof_generate_image_by_dot($dot_script, $type) {
 
   $cmd = " dot -T".$type;
 
-  $process = proc_open( $cmd, $descriptorspec, $pipes, sys_get_temp_dir() );
+  $process = proc_open( $cmd, $descriptorspec, $pipes, sys_get_temp_dir(), array( 'PATH' => getenv( 'PATH' ) ) );
   if (is_resource($process)) {
     fwrite($pipes[0], $dot_script);
     fclose($pipes[0]);


### PR DESCRIPTION
**Not** tested on Linux, just got it working on Windows with some trial and error.
1. Replaced hardcoded `/tmp` with `sys_get_temp_dir()`, there is some [usual lively discussion in PHP docs](http://php.net/manual/en/function.sys-get-temp-dir.php), might or might not be reliable func to use.
2. Passing empty `array()` for environment argument is different from default `null` and makes it fail to recognize `dot` command on Windows. I am not sure if passing it served some purpose or just unnecessary leftover.
