### PR TITLE
Ignore build artifacts from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 extension/*
+!extension/config.m4
 !extension/php_xhprof.h
+!extension/tests/
 !extension/xhprof.c


### PR DESCRIPTION
Git should automatically ignore any files created by the PHP build process.
