### PR TITLE
Whitelist for functions

### DIFF
--- a/extension/tests/xhprof_009.phpt
+++ b/extension/tests/xhprof_009.phpt
@@ -1,0 +1,25 @@
+--TEST--
+XHPRrof: Test excluding call_user_func and similar functions
+Author: mpal
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function test_stringlength($string)
+{
+    return strlen($string);
+}
+
+xhprof_enable(XHPROF_FLAGS_MEMORY, array('functions' => array('strlen')));
+test_stringlength('foo_array');
+$output = xhprof_disable();
+
+if (count($output) == 2 && isset($output['main()']) && isset($output['main()==>strlen'])) {
+    echo "Test passed";
+} else {
+    var_dump($output);
+}
+?>
+--EXPECT--
+Test passed

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -104,9 +104,9 @@
 #define XHPROF_SAMPLING_INTERVAL       100000      /* In microsecs        */
 
 /* Constant for ignoring functions, transparent to hierarchical profile */
-#define XHPROF_MAX_IGNORED_FUNCTIONS  256
-#define XHPROF_IGNORED_FUNCTION_FILTER_SIZE                           \
-               ((XHPROF_MAX_IGNORED_FUNCTIONS + 7)/8)
+#define XHPROF_MAX_FILTERED_FUNCTIONS  256
+#define XHPROF_FILTERED_FUNCTION_SIZE                           \
+               ((XHPROF_MAX_FILTERED_FUNCTIONS + 7)/8)
 
 #if !defined(uint64)
 typedef unsigned long long uint64;
@@ -218,9 +218,10 @@ typedef struct hp_global_t {
   /* counter table indexed by hash value of function names. */
   uint8  func_hash_counters[256];
 
-  /* Table of ignored function names and their filter */
-  char  **ignored_function_names;
-  uint8   ignored_function_filter[XHPROF_IGNORED_FUNCTION_FILTER_SIZE];
+  /* Table of filtered function names and their filter */
+  int     filtered_type; // 1 = blacklist, 2 = whitelist, 0 = nothing
+  char  **filtered_function_names;
+  uint8   filtered_function_filter[XHPROF_FILTERED_FUNCTION_SIZE];
 
 } hp_global_t;
 
@@ -284,9 +285,9 @@ static void get_all_cpu_frequencies();
 static long get_us_interval(struct timeval *start, struct timeval *end);
 static void incr_us_interval(struct timeval *start, uint64 incr);
 
-static void hp_get_ignored_functions_from_arg(zval *args);
-static void hp_ignored_functions_filter_clear();
-static void hp_ignored_functions_filter_init();
+static void hp_get_filtered_functions_from_arg(zval *args);
+static void hp_filtered_functions_filter_clear();
+static void hp_filtered_functions_filter_init();
 
 static inline zval  *hp_zval_at_key(char  *key,
                                     zval  *values);
@@ -387,7 +388,7 @@ PHP_FUNCTION(xhprof_enable) {
     return;
   }
 
-  hp_get_ignored_functions_from_arg(optional_array);
+  hp_get_filtered_functions_from_arg(optional_array);
 
   hp_begin(XHPROF_MODE_HIERARCHICAL, xhprof_flags TSRMLS_CC);
 }
@@ -416,7 +417,7 @@ PHP_FUNCTION(xhprof_disable) {
  */
 PHP_FUNCTION(xhprof_sample_enable) {
   long  xhprof_flags = 0;                                    /* XHProf flags */
-  hp_get_ignored_functions_from_arg(NULL);
+  hp_get_filtered_functions_from_arg(NULL);
   hp_begin(XHPROF_MODE_SAMPLED, xhprof_flags TSRMLS_CC);
 }
 
@@ -474,7 +475,7 @@ PHP_MINIT_FUNCTION(xhprof) {
     hp_globals.func_hash_counters[i] = 0;
   }
 
-  hp_ignored_functions_filter_clear();
+  hp_filtered_functions_filter_clear();
 
 #if defined(DEBUG)
   /* To make it random number generator repeatable to ease testing. */
@@ -595,14 +596,24 @@ static inline uint8 hp_inline_hash(char * str) {
  *
  * @author mpal
  */
-static void hp_get_ignored_functions_from_arg(zval *args) {
+static void hp_get_filtered_functions_from_arg(zval *args) {
   if (args != NULL) {
     zval  *zresult = NULL;
 
     zresult = hp_zval_at_key("ignored_functions", args);
-    hp_globals.ignored_function_names = hp_strings_in_zval(zresult);
+
+    if (zresult == NULL) {
+        zresult = hp_zval_at_key("functions", args);
+        if (zresult != NULL) {
+            hp_globals.filtered_type = 2;
+        }
+    } else {
+        hp_globals.filtered_type = 1;
+    }
+
+    hp_globals.filtered_function_names = hp_strings_in_zval(zresult);
   } else {
-    hp_globals.ignored_function_names = NULL;
+    hp_globals.filtered_function_names = NULL;
   }
 }
 
@@ -611,9 +622,10 @@ static void hp_get_ignored_functions_from_arg(zval *args) {
  *
  * @author mpal
  */
-static void hp_ignored_functions_filter_clear() {
-  memset(hp_globals.ignored_function_filter, 0,
-         XHPROF_IGNORED_FUNCTION_FILTER_SIZE);
+static void hp_filtered_functions_filter_clear() {
+  hp_globals.filtered_type = 0;
+  memset(hp_globals.filtered_function_filter, 0,
+         XHPROF_FILTERED_FUNCTION_SIZE);
 }
 
 /**
@@ -621,14 +633,14 @@ static void hp_ignored_functions_filter_clear() {
  *
  * @author mpal
  */
-static void hp_ignored_functions_filter_init() {
-  if (hp_globals.ignored_function_names != NULL) {
+static void hp_filtered_functions_filter_init() {
+  if (hp_globals.filtered_function_names != NULL) {
     int i = 0;
-    for(; hp_globals.ignored_function_names[i] != NULL; i++) {
-      char *str  = hp_globals.ignored_function_names[i];
+    for(; hp_globals.filtered_function_names[i] != NULL; i++) {
+      char *str  = hp_globals.filtered_function_names[i];
       uint8 hash = hp_inline_hash(str);
       int   idx  = INDEX_2_BYTE(hash);
-      hp_globals.ignored_function_filter[idx] |= INDEX_2_BIT(hash);
+      hp_globals.filtered_function_filter[idx] |= INDEX_2_BIT(hash);
     }
   }
 }
@@ -638,9 +650,9 @@ static void hp_ignored_functions_filter_init() {
  *
  * @author mpal
  */
-int hp_ignored_functions_filter_collision(uint8 hash) {
+int hp_filtered_functions_filter_collision(uint8 hash) {
   uint8 mask = INDEX_2_BIT(hash);
-  return hp_globals.ignored_function_filter[INDEX_2_BYTE(hash)] & mask;
+  return hp_globals.filtered_function_filter[INDEX_2_BYTE(hash)] & mask;
 }
 
 /**
@@ -679,7 +691,7 @@ void hp_init_profiler_state(int level TSRMLS_DC) {
   hp_globals.mode_cb.init_cb(TSRMLS_C);
 
   /* Set up filter of functions which may be ignored during profiling */
-  hp_ignored_functions_filter_init();
+  hp_filtered_functions_filter_init();
 }
 
 /**
@@ -702,8 +714,8 @@ void hp_clean_profiler_state(TSRMLS_D) {
   hp_globals.ever_enabled = 0;
 
   /* Delete the array storing ignored function names */
-  hp_array_del(hp_globals.ignored_function_names);
-  hp_globals.ignored_function_names = NULL;
+  hp_array_del(hp_globals.filtered_function_names);
+  hp_globals.filtered_function_names = NULL;
 }
 
 /*
@@ -718,7 +730,7 @@ void hp_clean_profiler_state(TSRMLS_D) {
   do {                                                                  \
     /* Use a hash code to filter most of the string comparisons. */     \
     uint8 hash_code  = hp_inline_hash(symbol);                          \
-    profile_curr = !hp_ignore_entry(hash_code, symbol);                 \
+    profile_curr = !hp_filter_entry(hash_code, symbol);                 \
     if (profile_curr) {                                                 \
       hp_entry_t *cur_entry = hp_fast_alloc_hprof_entry();              \
       (cur_entry)->hash_code = hash_code;                               \
@@ -799,31 +811,41 @@ size_t hp_get_entry_name(hp_entry_t  *entry,
 }
 
 /**
- * Check if this entry should be ignored, first with a conservative Bloomish
- * filter then with an exact check against the function names.
+ * Check if this entry should be filtered (positive or negative), first with a
+ * conservative Bloomish filter then with an exact check against the function
+ * names.
  *
  * @author mpal
  */
-int  hp_ignore_entry_work(uint8 hash_code, char *curr_func) {
-  int ignore = 0;
-  if (hp_ignored_functions_filter_collision(hash_code)) {
-    int i = 0;
-    for (; hp_globals.ignored_function_names[i] != NULL; i++) {
-      char *name = hp_globals.ignored_function_names[i];
-      if ( !strcmp(curr_func, name)) {
-        ignore++;
-        break;
+int  hp_filter_entry_work(uint8 hash_code, char *curr_func) {
+  int filter = 0;
+  if (hp_filtered_functions_filter_collision(hash_code)) {
+      int i = 0;
+      for (; hp_globals.filtered_function_names[i] != NULL; i++) {
+          char *name = hp_globals.filtered_function_names[i];
+          if (strcmp(curr_func, name) == 0) {
+              filter++;
+              break;
+          }
       }
-    }
   }
 
-  return ignore;
+  if (hp_globals.filtered_type == 2) {
+      // always include main() in profiling result.
+      if (strcmp(curr_func, ROOT_SYMBOL) == 0) {
+          filter = 0;
+      } else {
+          filter = abs(filter - 1);
+      }
+  }
+
+  return filter;
 }
 
-static inline int  hp_ignore_entry(uint8 hash_code, char *curr_func) {
+static inline int  hp_filter_entry(uint8 hash_code, char *curr_func) {
   /* First check if ignoring functions is enabled */
-  return hp_globals.ignored_function_names != NULL &&
-         hp_ignore_entry_work(hash_code, curr_func);
+  return hp_globals.filtered_function_names != NULL &&
+         hp_filter_entry_work(hash_code, curr_func);
 }
 
 /**
@@ -1703,8 +1725,18 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 
   if (!_zend_execute_internal) {
     /* no old override to begin with. so invoke the builtin's implementation  */
+#if ZEND_EXTENSION_API_NO >= 220121212
+    if (fci != NULL) {
+      ((zend_internal_function *) execute_data->function_state.function)->handler(fci->param_count,
+                       *fci->retval_ptr_ptr, fci->retval_ptr_ptr, fci->object_ptr, 1 TSRMLS_CC);
+    } else {
+      zval **return_value_ptr = &EX_TMP_VAR(execute_data, execute_data->opline->result.var)->var.ptr;
+      ((zend_internal_function *) execute_data->function_state.function)->handler(execute_data->opline->extended_value, *return_value_ptr,
+                       (execute_data->function_state.function->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)?return_value_ptr:NULL,
+                       execute_data->object, ret TSRMLS_CC);
+    }
+#elif ZEND_EXTENSION_API_NO >= 220100525
     zend_op *opline = EX(opline);
-#if ZEND_EXTENSION_API_NO >= 220100525
     temp_variable *retvar = &EX_T(opline->result.var);
     ((zend_internal_function *) EX(function_state).function)->handler(
                        opline->extended_value,
@@ -1713,6 +1745,7 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
                        &retvar->var.ptr:NULL,
                        EX(object), ret TSRMLS_CC);
 #else
+    zend_op *opline = EX(opline);
     ((zend_internal_function *) EX(function_state).function)->handler(
                        opline->extended_value,
                        EX_T(opline->result.u.var).var.ptr,
@@ -2010,7 +2043,7 @@ static char **hp_strings_in_zval(zval  *values) {
 static inline void hp_array_del(char **name_array) {
   if (name_array != NULL) {
     int i = 0;
-    for(; name_array[i] != NULL && i < XHPROF_MAX_IGNORED_FUNCTIONS; i++) {
+    for(; name_array[i] != NULL && i < XHPROF_MAX_FILTERED_FUNCTIONS; i++) {
       efree(name_array[i]);
     }
     efree(name_array);

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1725,8 +1725,8 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 
   if (!_zend_execute_internal) {
     /* no old override to begin with. so invoke the builtin's implementation  */
-#if ZEND_EXTENSION_API_NO >= 220100525
     zend_op *opline = EX(opline);
+#if ZEND_EXTENSION_API_NO >= 220100525
     temp_variable *retvar = &EX_T(opline->result.var);
     ((zend_internal_function *) EX(function_state).function)->handler(
                        opline->extended_value,
@@ -1735,7 +1735,6 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
                        &retvar->var.ptr:NULL,
                        EX(object), ret TSRMLS_CC);
 #else
-    zend_op *opline = EX(opline);
     ((zend_internal_function *) EX(function_state).function)->handler(
                        opline->extended_value,
                        EX_T(opline->result.u.var).var.ptr,

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -1725,17 +1725,7 @@ ZEND_DLEXPORT void hp_execute_internal(zend_execute_data *execute_data,
 
   if (!_zend_execute_internal) {
     /* no old override to begin with. so invoke the builtin's implementation  */
-#if ZEND_EXTENSION_API_NO >= 220121212
-    if (fci != NULL) {
-      ((zend_internal_function *) execute_data->function_state.function)->handler(fci->param_count,
-                       *fci->retval_ptr_ptr, fci->retval_ptr_ptr, fci->object_ptr, 1 TSRMLS_CC);
-    } else {
-      zval **return_value_ptr = &EX_TMP_VAR(execute_data, execute_data->opline->result.var)->var.ptr;
-      ((zend_internal_function *) execute_data->function_state.function)->handler(execute_data->opline->extended_value, *return_value_ptr,
-                       (execute_data->function_state.function->common.fn_flags & ZEND_ACC_RETURN_REFERENCE)?return_value_ptr:NULL,
-                       execute_data->object, ret TSRMLS_CC);
-    }
-#elif ZEND_EXTENSION_API_NO >= 220100525
+#if ZEND_EXTENSION_API_NO >= 220100525
     zend_op *opline = EX(opline);
     temp_variable *retvar = &EX_T(opline->result.var);
     ((zend_internal_function *) EX(function_state).function)->handler(


### PR DESCRIPTION
Add feature to xhprof_enable() allowing to pass whitelist of "functions" into the $options array, profiling only those functions:

```
xhprof_enable(0, array('functions' => array('strlen'));
$data = xhprof_disable();
```

Will now only contain `main()` and `main()==>strlen`.

Since xhprof puts a relation with a parent, the only parent to `strlen` in this case is `main()`. However if you have a list of many functions, there might be a function called between `main()` and `strlen` and it will be displayed as such.
