### PR TITLE
Fix Packagist Entry To Prevent Redirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,1 @@
-{
-    "name": "facebook/xhprof",
-    "type": "library",
-    "description": "XHProf: A Hierarchical Profiler for PHP",
-    "keywords": ["profiling", "performance"],
-    "homepage": "http://pecl.php.net/package/xhprof",
-    "license": "Apache-2.0",
-    "require": {
-        "php": ">=5.2.0"
-    },
-    "autoload": {
-        "files": [
-            "xhprof_lib/utils/xhprof_lib.php",
-            "xhprof_lib/utils/xhprof_runs.php"
-        ]
-    }
-}
+


### PR DESCRIPTION
Packagists entry for XHProf - see: https://packagist.org/packages/facebook/xhprof still points to https://github.com/facebook/xhprof.git despite having been moved to https://github.com/phacility/xhprof.git

This redirect causes composer to prompt for your github username/password unless you already have a ssh key registered with Github. In our automated environments this has caused havoc and we don't want to have to set up a github account just for our automated testing.

Please correct the packagist entry so it no longer redirects.  This will need to be done by logging into Packagist and updating where it points.

I would have registered this in Issues if it was turned on, but its not.  As such I made a faux pull request.
