### PR TITLE
Fix mismatched tag in contacts

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -50,7 +50,7 @@ XHProf is a function-level hierarchical profiler for PHP and has a simple HTML b
   <user>macvicar</user>
   <email>scott@fb.com</email>
   <active>yes</active>
- </developer>
+ </lead>
  <date>2009-03-28</date>
  <version>
   <release>0.9.2</release>


### PR DESCRIPTION
There was a mismatched XML tag in package.xml which prevented XHProf from being installed from source.
