### PR TITLE
Add xhprof_frame_begin & xhprof_frame_end

### DIFF
--- a/extension/php_xhprof.h
+++ b/extension/php_xhprof.h
@@ -41,5 +41,9 @@ PHP_FUNCTION(xhprof_enable);
 PHP_FUNCTION(xhprof_disable);
 PHP_FUNCTION(xhprof_sample_enable);
 PHP_FUNCTION(xhprof_sample_disable);
+PHP_FUNCTION(xhprof_frame_begin);
+PHP_FUNCTION(xhprof_frame_end);
 
+PHP_METHOD(XhprofFrame, __construct);
+PHP_METHOD(XhprofFrame, __destruct);
 #endif /* PHP_XHPROF_H */

--- a/extension/tests/xhprof_frame_01.phpt
+++ b/extension/tests/xhprof_frame_01.phpt
@@ -1,0 +1,40 @@
+--TEST--
+XHProf: xhprof_frame_* procedural interface
+Author: bd808
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function prodedural() {
+  xhprof_frame_begin('frame1');
+  inner();
+  xhprof_frame_begin('frame2');
+  inner();
+  xhprof_frame_begin('frame3');
+  inner();
+  xhprof_frame_end();
+  xhprof_frame_end();
+  xhprof_frame_end();
+}
+
+xhprof_enable();
+prodedural();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>prodedural                     : ct=       1; wt=*;
+main()==>xhprof_disable                 : ct=       1; wt=*;
+prodedural==>frame1                     : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_01.phpt
+++ b/extension/tests/xhprof_frame_01.phpt
@@ -10,7 +10,7 @@ function inner() {
   return;
 }
 
-function prodedural() {
+function procedural() {
   xhprof_frame_begin('frame1');
   inner();
   xhprof_frame_begin('frame2');
@@ -23,7 +23,7 @@ function prodedural() {
 }
 
 xhprof_enable();
-prodedural();
+procedural();
 $output = xhprof_disable();
 print_canonical($output);
 echo "\n";
@@ -35,6 +35,6 @@ frame2==>frame3                         : ct=       1; wt=*;
 frame2==>inner                          : ct=       1; wt=*;
 frame3==>inner                          : ct=       1; wt=*;
 main()                                  : ct=       1; wt=*;
-main()==>prodedural                     : ct=       1; wt=*;
+main()==>procedural                     : ct=       1; wt=*;
 main()==>xhprof_disable                 : ct=       1; wt=*;
-prodedural==>frame1                     : ct=       1; wt=*;
+procedural==>frame1                     : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_02.phpt
+++ b/extension/tests/xhprof_frame_02.phpt
@@ -1,0 +1,39 @@
+--TEST--
+XHProf: xhprof_frame_* procedural interface, XHPROF_FLAGS_NO_BUILTINS
+Author: bd808
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function prodedural() {
+  xhprof_frame_begin('frame1');
+  inner();
+  xhprof_frame_begin('frame2');
+  inner();
+  xhprof_frame_begin('frame3');
+  inner();
+  xhprof_frame_end();
+  xhprof_frame_end();
+  xhprof_frame_end();
+}
+
+xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
+prodedural();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>prodedural                     : ct=       1; wt=*;
+prodedural==>frame1                     : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_02.phpt
+++ b/extension/tests/xhprof_frame_02.phpt
@@ -10,7 +10,7 @@ function inner() {
   return;
 }
 
-function prodedural() {
+function procedural() {
   xhprof_frame_begin('frame1');
   inner();
   xhprof_frame_begin('frame2');
@@ -23,7 +23,7 @@ function prodedural() {
 }
 
 xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
-prodedural();
+procedural();
 $output = xhprof_disable();
 print_canonical($output);
 echo "\n";
@@ -35,5 +35,5 @@ frame2==>frame3                         : ct=       1; wt=*;
 frame2==>inner                          : ct=       1; wt=*;
 frame3==>inner                          : ct=       1; wt=*;
 main()                                  : ct=       1; wt=*;
-main()==>prodedural                     : ct=       1; wt=*;
-prodedural==>frame1                     : ct=       1; wt=*;
+main()==>procedural                     : ct=       1; wt=*;
+procedural==>frame1                     : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_03.phpt
+++ b/extension/tests/xhprof_frame_03.phpt
@@ -1,0 +1,48 @@
+--TEST--
+XHProf: xhprof_frame_* object interface
+Author: bd808
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+  die('skip this test for PHP <5.5; __destruct order incompatible');
+}
+?>
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function objects() {
+  $frame1 = new XhprofFrame('frame1');                                            inner();
+  $frame2 = new XhprofFrame('frame2');
+  inner();
+  $frame3 = new XhprofFrame('frame3');
+  inner();
+}
+
+xhprof_enable();
+objects();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>XhprofFrame::__construct       : ct=       1; wt=*;
+frame1==>XhprofFrame::__destruct        : ct=       1; wt=*;
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>XhprofFrame::__construct       : ct=       1; wt=*;
+frame2==>XhprofFrame::__destruct        : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>XhprofFrame::__construct       : ct=       1; wt=*;
+frame3==>XhprofFrame::__destruct        : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>objects                        : ct=       1; wt=*;
+main()==>xhprof_disable                 : ct=       1; wt=*;
+objects==>frame1                        : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_03.phpt
+++ b/extension/tests/xhprof_frame_03.phpt
@@ -17,7 +17,8 @@ function inner() {
 }
 
 function objects() {
-  $frame1 = new XhprofFrame('frame1');                                            inner();
+  $frame1 = new XhprofFrame('frame1');
+  inner();
   $frame2 = new XhprofFrame('frame2');
   inner();
   $frame3 = new XhprofFrame('frame3');

--- a/extension/tests/xhprof_frame_04.phpt
+++ b/extension/tests/xhprof_frame_04.phpt
@@ -11,7 +11,8 @@ function inner() {
 }
 
 function objects() {
-  $frame1 = new XhprofFrame('frame1');                                            inner();
+  $frame1 = new XhprofFrame('frame1');
+  inner();
   $frame2 = new XhprofFrame('frame2');
   inner();
   $frame3 = new XhprofFrame('frame3');

--- a/extension/tests/xhprof_frame_04.phpt
+++ b/extension/tests/xhprof_frame_04.phpt
@@ -1,0 +1,35 @@
+--TEST--
+XHProf: xhprof_frame_* object interface, XHPROF_FLAGS_NO_BUILTINS
+Author: bd808
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function objects() {
+  $frame1 = new XhprofFrame('frame1');                                            inner();
+  $frame2 = new XhprofFrame('frame2');
+  inner();
+  $frame3 = new XhprofFrame('frame3');
+  inner();
+}
+
+xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
+objects();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>objects                        : ct=       1; wt=*;
+objects==>frame1                        : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_05.phpt
+++ b/extension/tests/xhprof_frame_05.phpt
@@ -1,0 +1,49 @@
+--TEST--
+XHProf: xhprof_frame_* mixed procedural and object
+Author: bd808
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+  die('skip this test for PHP <5.5; __destruct order incompatible');
+}
+?>
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function mixed() {
+  $frame1 = new XhprofFrame('frame1');
+  inner();
+  xhprof_frame_begin('frame2');
+  inner();
+  $frame3 = new XhprofFrame('frame3');
+  inner();
+  unset($frame3);
+  xhprof_frame_end();
+}
+
+xhprof_enable();
+mixed();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>XhprofFrame::__construct       : ct=       1; wt=*;
+frame1==>XhprofFrame::__destruct        : ct=       1; wt=*;
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>XhprofFrame::__construct       : ct=       1; wt=*;
+frame3==>XhprofFrame::__destruct        : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>mixed                          : ct=       1; wt=*;
+main()==>xhprof_disable                 : ct=       1; wt=*;
+mixed==>frame1                          : ct=       1; wt=*;

--- a/extension/tests/xhprof_frame_06.phpt
+++ b/extension/tests/xhprof_frame_06.phpt
@@ -1,0 +1,38 @@
+--TEST--
+XHProf: xhprof_frame_* mixed procedural and object, XHPROF_FLAGS_NO_BUILTINS
+Author: bd808
+--FILE--
+<?php
+
+include_once dirname(__FILE__).'/common.php';
+
+function inner() {
+  return;
+}
+
+function mixed() {
+  $frame1 = new XhprofFrame('frame1');
+  inner();
+  xhprof_frame_begin('frame2');
+  inner();
+  $frame3 = new XhprofFrame('frame3');
+  inner();
+  unset($frame3);
+  xhprof_frame_end();
+}
+
+xhprof_enable(XHPROF_FLAGS_NO_BUILTINS);
+mixed();
+$output = xhprof_disable();
+print_canonical($output);
+echo "\n";
+?>
+--EXPECT--
+frame1==>frame2                         : ct=       1; wt=*;
+frame1==>inner                          : ct=       1; wt=*;
+frame2==>frame3                         : ct=       1; wt=*;
+frame2==>inner                          : ct=       1; wt=*;
+frame3==>inner                          : ct=       1; wt=*;
+main()                                  : ct=       1; wt=*;
+main()==>mixed                          : ct=       1; wt=*;
+mixed==>frame1                          : ct=       1; wt=*;


### PR DESCRIPTION
Add functions for sub-function profiling.
- `xhprof_frame_begin` : Starts an artificial frame. Together with
  `xhprof_frame_end`, this times one block of code execution as if it
  were a function call, allowing people to define arbitrary function
  boundaries.
- `xhprof_frame_end` : Ends an artificial frame that `xhprof_frame_begin`
  started. One has to make sure there are no exceptions in between these
  two calls, as otherwise, it may report incorrect timings. Also,
  `xhprof_frame_begin` and `xhprof_frame_end` have to be paired up
  really well, so not to interfere with regular function's profiling,
  unless that's the intention.
- `XhprofFrame` : Wrapper object that calls `xhprof_frame_begin` in its
  constructor and `xhprof_frame_end` in its destructor.

This functionality was back ported from HHVM's internal XHProf
implementation. There has been one small change from the HHVM
implementation with the addition of the optional `$wrapped` boolean
parameter to `xhprof_frame_begin` which is used to fix a bug in the
upstream `XhprofFrame` implementation which mis-attibutes function calls
in a frame introduced via `XhprofFrame` to `XhprofFrame::__construct`
rather than the name provided for the frame.

Fixes #51 
