### PR TITLE
Call hp_array_del() from hp_get_ignored_functions_from_arg()

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -596,6 +596,9 @@ static inline uint8 hp_inline_hash(char * str) {
  * @author mpal
  */
 static void hp_get_ignored_functions_from_arg(zval *args) {
+  /* Clean up any existing ignored function list */
+  hp_array_del(hp_globals.ignored_function_names);
+
   if (args != NULL) {
     zval  *zresult = NULL;
 


### PR DESCRIPTION
Call `hp_array_del` to clean up any existing list of ignored function
names before allocating a new list or clearing the pointer.

Closes #53