### PR TITLE
fix minor memleak fix in xhprof_enable() with ignored funcs

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -596,6 +596,11 @@ static inline uint8 hp_inline_hash(char * str) {
  * @author mpal
  */
 static void hp_get_ignored_functions_from_arg(zval *args) {
+
+  if (hp_globals.ignored_function_names) {
+    hp_array_del(hp_globals.ignored_function_names);
+  }
+
   if (args != NULL) {
     zval  *zresult = NULL;
 


### PR DESCRIPTION
the ignored funcs array (and its elements) is freed only on shutdown, so every xhprof_enable() call causes a minor memleak.