### PR TITLE
fixed segfault with auto_append_file

### DIFF
--- a/extension/tests/xhprof_append.phpt
+++ b/extension/tests/xhprof_append.phpt
@@ -1,0 +1,16 @@
+--TEST--
+xhprof + auto_append_file
+--INI--
+auto_append_file=./xhprof_append_test_artefact.php
+--FILE--
+<?php
+
+file_put_contents("./xhprof_append_test_artefact.php", "<?php var_dump('append'); ?>");
+
+xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY);
+
+echo "END\n";
+?>
+--EXPECTF--
+END
+string(6) "append"

--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -962,7 +962,11 @@ static char *hp_get_function_name(zend_op_array *ops TSRMLS_DC) {
        * include, eval, etc.
        */
 #if ZEND_EXTENSION_API_NO >= 220121212
-      curr_op = data->prev_execute_data->opline->extended_value;
+      if (data->prev_execute_data) {
+        curr_op = data->prev_execute_data->opline->extended_value;
+      } else {
+        curr_op = data->opline->extended_value;
+      }
 #elif ZEND_EXTENSION_API_NO >= 220100525
       curr_op = data->opline->extended_value;
 #else


### PR DESCRIPTION
The segfault happens because data->prev_execute_data is NULL in the appended file.
