### PR TITLE
Change version # to 0.9.4 to match PECL release

### DIFF
--- a/extension/xhprof.c
+++ b/extension/xhprof.c
@@ -76,7 +76,7 @@
  */
 
 /* XHProf version                           */
-#define XHPROF_VERSION       "0.9.2"
+#define XHPROF_VERSION       "0.9.4"
 
 /* Fictitious function name to represent top of the call tree. The paranthesis
  * in the name is to ensure we don't conflict with user function names.  */


### PR DESCRIPTION
Pecl is showing 0.9.4, yet the code is set to 0.9.2, which causes an inconsistency when trying to lookup the version number:

``` php
>>> $x = new \ReflectionExtension("xhprof");
>>> $x->getVersion();
=> "0.9.2"
```
