### PR TITLE
Allow to specify 'xhprof.output_dir' without xhprof available

### DIFF
--- a/xhprof_lib/utils/xhprof_runs.php
+++ b/xhprof_lib/utils/xhprof_runs.php
@@ -92,7 +92,7 @@ class XHProfRuns_Default implements iXHProfRuns {
     // in which the error_log file resides.
 
     if (empty($dir)) {
-      $dir = ini_get("xhprof.output_dir");
+      $dir = get_cfg_var("xhprof.output_dir");
       if (empty($dir)) {
 
         $dir = sys_get_temp_dir();


### PR DESCRIPTION
If the xhprof extension is not installed, `ini_get()` doesn't work but `get_cfg_var()` still return the value:
```
php > print_r(ini_get('xhprof.output_dir'));
php > print_r(get_cfg_var('xhprof.output_dir'));
/test/
```
This allow to use the UI with `tideways` for instance or on a separate server.