### PR TITLE
Update Travis CI config for PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
+sudo: required
 language: php
 
 notifications:
   email: false
 
 php:
-  - 5.5
-  - 5.4
-  - 5.3
-  - 5.3.3
+  - 7.0
+  - 7.1
 
 env:
   global:


### PR DESCRIPTION
* Explicitly require sudo given this is no longer the default for new repos/new branches.
* Explicitly use the less-old Ubuntu 14 Trusty images instead of the legacy 12 Precise ones.
* Replace PHP 5.x matrix with 7.0 and 7.1.
